### PR TITLE
Update CMB2 inclusion check

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -36,7 +36,7 @@ class YoastCMB2Analysis {
   }
 
   public function check_for_cmb2() {
-    if(!is_plugin_active('cmb2/init.php') && !has_action('cmb2_init')) {
+    if(!class_exists('CMB2', false) && !defined('CMB2_LOADED')) {
       add_action('admin_notices', [$this, 'require_cmb2_message']);
 
       return true;


### PR DESCRIPTION
- Remove check for `cmb2` plugin and `init` method is too specific and
  does not catch instances of cmb2 loaded bundled with different themes or
  as dependancies of other plugins. Instead it checks for the `CMB2` class
  and the `CMB2_LOADED` constant
- Fixes #2
