### PR TITLE
Bugfix load order of scripts for Yoast 9.5+

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -16,7 +16,7 @@ class YoastCMB2Analysis {
 
   public function __construct() {
     add_action('admin_init', [$this, 'plugin_admin_setup']);
-    add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts']);
+    add_action('admin_enqueue_scripts', [$this, 'enqueue_scripts'], 99);
   }
 
   public function plugin_admin_setup() {


### PR DESCRIPTION
* Updates plugins script enqueued later in load process to ensure this happens after other plugins, i.e. Yoast, have been loaded

* Tested on WP 5.0.3, Yoast 9.5 & 9.6

* Fixes #12, #11 